### PR TITLE
fix: remove index files

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,9 @@ create `db:generate` and `db:migrate` for generating the sources and migrating t
 
 ## Using this package
 
-Simply import `@yes-theory-fam/database` to get access to both everything generated to `@prisma/client` and all
-exported `type-graphql` code. If you don't have type-graphql installed, you have to import
-from `@yes-theory-fam/database/client` which only exports the Prisma client to avoid TypeScript errors.
+Simply import `@yes-theory-fam/database/client` to get access everything generated to `@prisma/client` and
+`@yes-theory-fam/database/type-graphql` to get all the exported `type-graphql` code. This split is done to avoid
+TypeScript errors since Prisma and TypeGraphQL generate types with identical names. 
 
 ### Seeding the database
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,0 @@
-export * from "@prisma/client";
-export * from "./src/__generated__/type-graphql";

--- a/index.js
+++ b/index.js
@@ -1,4 +1,0 @@
-const client = require("./client");
-const typeGraphQL = require("./type-graphql");
-
-module.exports = {...client, ...typeGraphQL};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yes-theory-fam/database",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "main": "index.js",
   "repository": "git://github.com/yes-theory-fam/database.git",
   "license": "MIT",
@@ -21,6 +21,8 @@
     "@prisma/client": "~2.27.0"
   },
   "devDependencies": {
+    "graphql": "15.5.0",
+    "graphql-fields": "2.0.3",
     "install": "0.13.0",
     "npm": "7.19.1",
     "prisma": "2.27.0",
@@ -28,7 +30,9 @@
     "typegraphql-prisma": "0.14.7"
   },
   "peerDependencies": {
-    "prisma": "~2.26.0 || ~2.27.0",
+    "graphql": "15.5.0",
+    "graphql-fields": "2.0.3",
+    "prisma": "~2.27.0",
     "typegraphql-prisma": "^0.14.6"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1241,6 +1241,11 @@ graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.2.0, graceful-fs@^4.2.3,
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
   integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
+graphql-fields@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/graphql-fields/-/graphql-fields-2.0.3.tgz#5e68dff7afbb202be4f4f40623e983b22c96ab8f"
+  integrity sha512-x3VE5lUcR4XCOxPIqaO4CE+bTK8u6gVouOdpQX9+EKHr+scqtK5Pp/l8nIGqIpN1TUlkKE6jDCCycm/WtLRAwA==
+
 graphql-query-complexity@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/graphql-query-complexity/-/graphql-query-complexity-0.7.2.tgz#7fc6bb20930ab1b666ecf3bbfb24b65b6f08ecc4"
@@ -1254,6 +1259,11 @@ graphql-subscriptions@^1.1.0:
   integrity sha512-95yD/tKi24q8xYa7Q9rhQN16AYj5wPbrb8tmHGM3WRc9EBmWrG/0kkMl+tQG8wcEuE9ibR4zyOM31p5Sdr2v4g==
   dependencies:
     iterall "^1.3.0"
+
+graphql@15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.5.0.tgz#39d19494dbe69d1ea719915b578bf920344a69d5"
+  integrity sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==
 
 har-schema@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The generated code from Prisma and TypeGraphQL-Prisma shares the names of the entities and leads to TypeScript errors. To avoid this problem in the future, the index files which export both sources were removed, the documentation was updated to reflect the change.