### PR TITLE
fix: constraint not existing in migration

### DIFF
--- a/prisma/migrations/20210703125246_user_group_delete_on_cascade/migration.sql
+++ b/prisma/migrations/20210703125246_user_group_delete_on_cascade/migration.sql
@@ -1,5 +1,5 @@
 -- DropForeignKey
-ALTER TABLE "user_group_members_group_member" DROP CONSTRAINT "user_group_members_group_member_groupMemberId_fkey";
+ALTER TABLE "user_group_members_group_member" DROP CONSTRAINT IF EXISTS "user_group_members_group_member_groupMemberId_fkey";
 
 -- AddForeignKey
 ALTER TABLE "user_group_members_group_member" ADD FOREIGN KEY ("groupMemberId") REFERENCES "group_member"("id") ON DELETE RESTRICT ON UPDATE CASCADE;


### PR DESCRIPTION
Migrations including this script tended to fail in production because the constraint didn't exist yet. This fixes the migration script to allow for future scripts. Given that the constraint is recreated afterwards, this should not break anything and has to be done here since a new migration wouldn't make any sense.