### PR TITLE
chore: remove deprecated preview action

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,7 +1,6 @@
 generator client {
   provider        = "prisma-client-js"
   binaryTargets   = ["native", "linux-musl", "darwin", "windows", "debian-openssl-1.1.x", "debian-openssl-1.1.x"]
-  previewFeatures = ["referentialActions"]
 }
 
 generator typegraphql {


### PR DESCRIPTION
Currently generating the sources shows this warning:

![grafik](https://user-images.githubusercontent.com/26303198/135759973-698e204a-9f39-42a9-bc7a-c5e6cfa3f38d.png)

This PR removes that preview feature flag as suggested in the warning.