### PR TITLE
chore: downgrade graphql peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "typegraphql-prisma": "0.18.2"
   },
   "peerDependencies": {
-    "graphql": "16.0.0",
+    "graphql": "15.7.2",
     "graphql-fields": "2.0.3",
     "prisma": "3.6.0",
     "typegraphql-prisma": "0.18.2"


### PR DESCRIPTION
typegraphql-prisma and its devDependency type-graphql require a 15.x.x version of graphql; that slipped through in one of the many renovate sessions.

This PR changes the peerDependency to the latest 15.x.x release of graphql